### PR TITLE
Update helm chart for 0.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,14 @@ $ helm delete [RELEASE_NAME]
 
 Please check the following command for Helm v3:
 
+
 ```console
-# Helm install with tremor namespace already created
-$ helm install -n tremor [RELEASE_NAME] [HELM_REPO_NAME]]/tremor
 
 # Helm install and create namespace
-$ helm install -n tremor [RELEASE_NAME] [HELM_REPO_NAME]]/tremor --create-namespace
+$ helm install -n tremor [RELEASE_NAME] [HELM_REPO_NAME]/tremor --create-namespace
+
+# Helm install with tremor namespace already created
+$ helm install -n tremor [RELEASE_NAME] [HELM_REPO_NAME]/tremor
 
 ```
 

--- a/charts/tremor/Chart.yaml
+++ b/charts/tremor/Chart.yaml
@@ -28,6 +28,6 @@ appVersion: "1.0"
 description: "Chart to deploy a tremor instance"
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/tremor/horizontal/color/tremor-horizontal-color.png
 name: "tremor"
-version: "0.2.1"
+version: "0.13.0-rc.12"
 maintainers:
   - name: tremor-rs

--- a/charts/tremor/values.yaml
+++ b/charts/tremor/values.yaml
@@ -48,29 +48,33 @@ extraVolumeMounts: []
 extraVolumes: {}
 
 files:
-  config.yaml: |-
-    onramp:
-      - id: metronome
-        type: metronome
-        config:
-          interval: 10000
-    binding:
-      - id: default
-        links:
-          '/onramp/metronome/{instance}/out': [ '/pipeline/main/{instance}/in' ]
-          '/pipeline/main/{instance}/out': [ '/offramp/system::stdout/system/in' ]
-          '/pipeline/system::metrics/system/out': [ '/offramp/system::stdout/system/in' ]
-    mapping:
-      /binding/default/01:
-        instance: '01'
-  main.trickle: select event from in into out
+  main.troy: |-
+    define flow main
+    flow
+      use std::time::nanos;
+      use tremor::pipelines;
+      use tremor::connectors;
+      define connector every_second from metronome
+      with
+        config = {"interval": nanos::from_seconds(2)}
+      end;
+
+      create connector every_second;
+      create connector console from connectors::console;
+      create pipeline main from pipelines::passthrough;
+
+      connect /connector/every_second to /pipeline/main;
+      connect /pipeline/main to /connector/console;
+    end;
+
+    deploy flow main
 
 fullnameOverride: ''
 
 image:
   pullPolicy: IfNotPresent
   repository: tremorproject/tremor
-  tag: 0.11.4
+  tag: 0.13.0-rc.12
 
 # Tremor can be deployed as a DaemonSet as well
 kind: DaemonSet


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a minor update to the helm chart, mostly the default, to use 0.13's troy files instead of the yaml

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>` format)*:

**Special notes for reviewers**:
